### PR TITLE
Update Santa Cruz image URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
 
     <div class="cam-block">
       <a href="https://www.usgs.gov/media/webcams/santa-cruz-main-beach-webcam-snapshot">
-        <img src="https://argusdata.s3.amazonaws.com/dreaminn/latest/c1_snap.jpg" />
+        <img src="https://cmgp-coastcam.s3-us-west-2.amazonaws.com/cameras/dreaminn/latest/c1_snap.jpg" />
       </a>
       <p class="location">Santa Cruz Main Beach</p>
       <p class="copyright">USGS</p>


### PR DESCRIPTION
Thanks for publishing this site! Have thought about making something similar before and a 🚲 friend passed this along. The GGB webcam is a bit of a pain, but I wrote this way back and it still works:

https://github.com/bendrucker/golden-gate

In any case...

<hr>

The USGS now publishes these images to a different S3 bucket. The old bucket no longer resolves.

```
$ curl --head https://argusdata.s3.amazonaws.com/dreaminn/latest/c1_snap.jpg

HTTP/1.1 403 Forbidden
x-amz-request-id: FF65FEDC9AB84249
x-amz-id-2: xPhr5wN/wbpXQ7HY96dewjvYfzTLgaN5X6KgTlUfPBY8n/b6twS8UmdSK1HQN8wDJgNAzrVqsKc=
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Thu, 04 Jun 2020 20:46:31 GMT
Server: AmazonS3

$ curl --head https://cmgp-coastcam.s3-us-west-2.amazonaws.com/cameras/dreaminn/latest/c1_snap.jpg

HTTP/1.1 200 OK
x-amz-id-2: K77CjhpU3+QurDge/OAkQ6SiOcV0ed7zlY/62JbvtDwHEtRR8pEEwy+OUtpt94g6uuCvMk7gl3s=
x-amz-request-id: 3CA16C5F869EAF52
Date: Thu, 04 Jun 2020 20:46:41 GMT
Last-Modified: Thu, 04 Jun 2020 20:42:05 GMT
ETag: "83470f2bde33aa2c64512fe299f7affb"
x-amz-meta-s3cmd-attrs: uid:0/gname:root/uname:root/gid:0/mode:33279/mtime:1591303276/atime:1591303276/md5:83470f2bde33aa2c64512fe299f7affb/ctime:1591303276
Accept-Ranges: bytes
Content-Type: image/jpeg
Content-Length: 464864
Server: AmazonS3
```